### PR TITLE
Allow customizing the name of the input file in fixtures (overriding `code.js`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ fixtures('my plugin', path.join(__dirname, '__fixtures__'), {
 
 By default, it will compare the outputs with the files on the filesystem and you have to manually update the files in case of a mismatch. If you're using Jest, you can use the snapshot feature to automatically update the files with a keypress. ([See below](#integration-with-jest-snapshot)) on how to set it up.
 
+### Customizing the test file name
+
+Sometimes, the name of the test file can be relevant to the test itself. In that case, the default name of `code.js` can be overridden by specifying a `babel-test.json` configuration file inside the fixture directory:
+
+```sh
+.
+├── function-expression
+│   ├── code.js
+│   └── output.js
+├── invalid-syntax
+│   ├── code.js
+│   └── error.js
+└── simple-variable
+    ├── babel-test.json
+    ├── input.js
+    └── output.js
+```
+
+The configuration file supports a single option: `inputFileName`, which specifies the name to use instead of `code.js`.
+
+```json
+{
+  "inputFileName": "input.js"
+}
+```
+
+The name of `output.js` cannot be overridden.
+
 ### Standalone test
 
 To run a standalone test with some custom logic, you can use the `test` function returned from `create`:

--- a/src/__fixtures__/custom-file-name/babel-test.json
+++ b/src/__fixtures__/custom-file-name/babel-test.json
@@ -1,0 +1,3 @@
+{
+  "inputFileName": "input.js"
+}

--- a/src/__fixtures__/custom-file-name/input.js
+++ b/src/__fixtures__/custom-file-name/input.js
@@ -1,0 +1,1 @@
+var title = 'hello world';

--- a/src/__fixtures__/custom-file-name/output.js
+++ b/src/__fixtures__/custom-file-name/output.js
@@ -1,0 +1,1 @@
+var eltit = 'hello world';

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,9 @@ exports.create = function create(config) {
           : it;
 
         t(f.replace(/^(skip|only)\./, '').replace(/(-|_)/g, ' '), () => {
-          const filename = path.join(path.join(directory, f), 'code.js');
+          const testDirectory = path.join(directory, f);
+          const testConfig = loadTestConfig(testDirectory);
+          const filename = path.join(testDirectory, testConfig.inputFileName);
           const content = fs.readFileSync(filename, 'utf8');
 
           return Promise.resolve(callback(content, { filename })).then(
@@ -228,3 +230,17 @@ exports.create = function create(config) {
 
   return { test, fixtures };
 };
+
+function loadTestConfig(directory) {
+  const configFilename = path.join(directory, 'babel-test.json');
+  const defaultConfig = {
+    inputFileName: 'code.js',
+  };
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configFilename, 'utf8'));
+    return Object.assign(defaultConfig, config);
+  } catch (_) {
+    return defaultConfig;
+  }
+}


### PR DESCRIPTION
This PR adds an option to override the default name of the code input in fixture directories from `code.js` to something else.

With this PR, the user will be able to add a `babel-test.json` configuration file containing the `inputFileName` parameter and override the default `code.js` value.

### Rationale

The name of the file being transformed may affect the functionality of the transformer. This is the case of [styled-components/babel-plugin-styled-components](https://github.com/styled-components/babel-plugin-styled-components): this transformer adds useful debugging information by annotating the generated class names with the component names ([see their docs](https://styled-components.com/docs/tooling#better-debugging)).

To generate the display name of the component, they use a combination of the file name and the component name. For example, for the styled-component `SubmitButton` inside the file `Forms.tsx`, they will generate `Forms_SubmitButton`. If we had a `Forms/SubmitButton/index.tsx` structure, `index_Forms` would look bad and not be very useful, which is why, when the file name is `index`, they look at the directory name instead to still generate `Forms_SubmitButton`.

Now, this library can't currently test this case, because it can't name the test file `index.js`. It must be named `code.js`

### More configuration?

I appreciate the value of opinionated libraries, and understand that this library has made an effort to enforce a consistent pattern. Adding configuration is not something to be done lightly, as it increases the complexity of the code and makes the library harder to reason about. I'd understand if this PR was rejected in favor of protecting the simplicity of the library.

However, I believe that in this case, adding this is fine, because:

* It solves a real limitation of the library, not a style preference.
* It is opt-in, and doesn't add any burden to new users of the library.
* Creating a `babel-test.json` for each fixture is an intentional friction. There is no way to override the "global" default name. This ensures that using the default `code.js` stays always more convenient, and it is only overridden when necessary. Thus:
    * The enforced convention is protected. You won't have developers renaming it to `input.js` just because they like it better.
    * The file name is semantic. If it is named `code.js`, the test probably doesn't care about it. If there is a `babel-config.json` file and the file name is other than `code.js`, the developer can immediately understand that there is something important about the file name.
* An alternative would be to [use a standalone test](https://github.com/satya164/babel-test/tree/9ff771fd11c258884bbe5564945e66d9b269a19a#standalone-test), but this would increase the complexity of the test suite. It would make the developer think "why do we always use the `fixtures` directory except on this one test?", which defeats the point of having an opinionated convention.

### Example usage

This PR adds tests which use a file named `input.js`. But you can see a real-world usage on [this commit](https://github.com/mellamopablo/babel-plugin-styled-components/commit/20b1be147076287a330244f1aff18693852112ef), where I implement the missing test that styled-components/babel-plugin-styled-components lacks.

Thanks for reading, and I'll be happy to make any changes or address any feedback!